### PR TITLE
Refresh Maven tooling versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.15.0</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
@@ -126,7 +126,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>3.5.0</version>
         <configuration>
           <archive>
             <manifestFile>src/META-INF/MANIFEST.MF</manifestFile>
@@ -139,6 +139,7 @@
 
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.11.0</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -156,7 +157,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.4.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -170,7 +171,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.2.8</version>
         <executions>
           <execution>
             <id>sign-artifacts</id>
@@ -192,7 +193,7 @@
       <plugin>
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
-        <version>0.8.0</version>
+        <version>0.10.0</version>
         <extensions>true</extensions>
         <configuration>
           <publishingServerId>central</publishingServerId>
@@ -203,7 +204,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.1</version>
+        <version>3.5.6</version>
         <configuration>
           <skip>false</skip>
         </configuration>
@@ -212,7 +213,7 @@
       <plugin>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-maven-plugin</artifactId>
-        <version>4.8-1</version>
+        <version>4.13.2</version>
         <executions>
           <execution>
             <id>antlr</id>
@@ -229,7 +230,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.12.0</version>
         <executions>
           <execution>
             <goals>
@@ -246,7 +247,7 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>4.8.0</version>
+        <version>4.9.10</version>
         <executions>
           <execution>
             <goals>
@@ -259,7 +260,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.6.3</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
## Summary
- refresh Maven build plugin versions to match standard-types where the build models overlap
- add an explicit maven-dependency-plugin version
- update sobject-types-only Scala and exec Maven plugins

## Tests
- mvn -q -DskipTests package
- mvn -q -Dgpg.skip=true install
