### PR TITLE
Add GenderIdentity and Pronouns fields to Contact and person Account stubs

### DIFF
--- a/src/main/java/io/github/apexdevtools/sobjecttypes/Account.java
+++ b/src/main/java/io/github/apexdevtools/sobjecttypes/Account.java
@@ -91,6 +91,7 @@ public class Account extends SObject {
 	public Datetime PersonEmailBouncedDate;
 	public String PersonEmailBouncedReason;
 	public String PersonGender;
+	public String PersonGenderIdentity;
 	public String PersonHomePhone;
 	public Id PersonIndividualId;
 	public Individual PersonIndividual;
@@ -122,6 +123,7 @@ public class Account extends SObject {
 	public String PersonOtherState;
 	public String PersonOtherStateCode;
 	public String PersonOtherStreet;
+	public String PersonPronouns;
 	public Integer PersonSequenceInMultipleBirth;
 	public String PersonTitle;
 	public String Phone;

--- a/src/main/java/io/github/apexdevtools/sobjecttypes/AccountChangeEvent.java
+++ b/src/main/java/io/github/apexdevtools/sobjecttypes/AccountChangeEvent.java
@@ -78,6 +78,7 @@ public class AccountChangeEvent extends SObject {
 	public Datetime PersonEmailBouncedDate;
 	public String PersonEmailBouncedReason;
 	public String PersonGender;
+	public String PersonGenderIdentity;
 	public String PersonHomePhone;
 	public Id PersonIndividualId;
 	public Individual PersonIndividual;
@@ -109,6 +110,7 @@ public class AccountChangeEvent extends SObject {
 	public String PersonOtherState;
 	public String PersonOtherStateCode;
 	public String PersonOtherStreet;
+	public String PersonPronouns;
 	public Integer PersonSequenceInMultipleBirth;
 	public String PersonTitle;
 	public String Phone;

--- a/src/main/java/io/github/apexdevtools/sobjecttypes/Contact.java
+++ b/src/main/java/io/github/apexdevtools/sobjecttypes/Contact.java
@@ -37,6 +37,7 @@ public class Contact extends SObject {
 	public String EmailBouncedReason;
 	public String Fax;
 	public String FirstName;
+	public String GenderIdentity;
 	public Boolean HasOptedOutOfEmail;
 	public Boolean HasOptedOutOfFax;
 	public Boolean HasPrivacyHold;
@@ -91,6 +92,7 @@ public class Contact extends SObject {
 	public User Owner;
 	public String Phone;
 	public String PhotoUrl;
+	public String Pronouns;
 	public Id ReportsToId;
 	public Contact ReportsTo;
 	public String Salutation;

--- a/src/main/java/io/github/apexdevtools/sobjecttypes/ContactChangeEvent.java
+++ b/src/main/java/io/github/apexdevtools/sobjecttypes/ContactChangeEvent.java
@@ -36,6 +36,7 @@ public class ContactChangeEvent extends SObject {
 	public String EmailBouncedReason;
 	public String Fax;
 	public String FirstName;
+	public String GenderIdentity;
 	public Boolean HasOptedOutOfEmail;
 	public Boolean HasOptedOutOfFax;
 	public String HomePhone;
@@ -80,6 +81,7 @@ public class ContactChangeEvent extends SObject {
 	public Id OwnerId;
 	public User Owner;
 	public String Phone;
+	public String Pronouns;
 	public String ReplayId;
 	public Id ReportsToId;
 	public Contact ReportsTo;


### PR DESCRIPTION
## Summary
- Fixes #27 — `Contact.GenderIdentity` (and `Pronouns`) were missing from the stubs.
- Root cause: these standard optional picklist fields (available since API 57.0) ship with **no field-level security granted to any profile**, and stub generation works from `describe` results, which only include FLS-visible fields. So they never appeared for Contact. Lead/Prospect stubs already had them because the fields were FLS-visible to the generating user in the scratch org. This is not a picklist-type handling issue — picklists map to `String` as usual.
- Added the fields wherever they exist in setup metadata (verified via `FieldDefinition` Tooling API queries against both a Summer '26 scratch org and a pre-release org):
  - `Contact` / `ContactChangeEvent`: `GenderIdentity`, `Pronouns`
  - `Account` / `AccountChangeEvent` (person accounts): `PersonGenderIdentity`, `PersonPronouns`

## Testing
- `mvn -B install -Dgpg.skip` passes locally (same as CI Build.yml).